### PR TITLE
test: stabilize extraction CI with fixtures and gated integration tests

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,12 @@ Edit `config.yaml` (optional). Defaults: Unity 6.3 URL, paths under `data/unity/
 pytest
 ```
 
+Optional real-doc extraction integration tests:
+```
+UNITYDOCS_E2E=1 pytest tests/test_extraction.py
+```
+These require local Unity raw docs under `data/unity/<version>/raw/UnityDocumentation`.
+
 ## Notes
 - Bake/index steps are idempotent: existing artifacts with matching config/version skip work.
 - Link extraction ignores external and anchor-only links; internal links are normalized to doc_ids for related lookups.

--- a/tests/fixtures/manual_index.html
+++ b/tests/fixtures/manual_index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Create and run a job</title>
+    <link rel="canonical" href="https://docs.unity3d.com/6000.3/Documentation/Manual/job-system-creating-jobs.html" />
+  </head>
+  <body>
+    <div id="content-wrap">
+      <div class="section">
+        <h1>Create and run a job</h1>
+        <p>
+          Unity jobs let you schedule small units of work so the main thread can keep rendering and gameplay responsive.
+          A job typically operates on NativeArray data, is scheduled from the main thread, and completed when the results
+          are needed. This fixture intentionally contains enough text to exercise markdown conversion and extraction logic.
+        </p>
+        <h2>Schedule and Complete best practices</h2>
+        <p>
+          Use JobHandle dependencies to chain work, avoid forcing the main thread to wait too early, and call Complete as
+          late as possible when you need job results. This helps maximize parallel throughput and keeps frame time stable.
+        </p>
+        <p>
+          For data-parallel workloads, use IJobParallelFor with a tuned batch count and avoid oversynchronizing unrelated
+          jobs. Profiling helps determine whether you should split long jobs into smaller dependent jobs.
+        </p>
+        <a href="../ScriptReference/Unity.Jobs.IJobParallelFor.html">IJobParallelFor API</a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/scriptref_iJobParallelFor.html
+++ b/tests/fixtures/scriptref_iJobParallelFor.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>IJobParallelFor</title>
+    <link rel="canonical" href="https://docs.unity3d.com/6000.3/Documentation/ScriptReference/Unity.Jobs.IJobParallelFor.html" />
+  </head>
+  <body>
+    <div id="content-wrap">
+      <div class="section">
+        <h1>IJobParallelFor</h1>
+        <p>
+          IJobParallelFor defines an Execute method that runs once per index in a NativeArray-style data source.
+          Unity partitions work into batches and schedules these across worker threads to improve throughput on
+          multicore CPUs. This fixture is representative rather than canonical documentation content.
+        </p>
+        <h2>Description</h2>
+        <p>
+          Implement Execute(int index) to process one element at a time. Use Schedule(length, batchSize) to control
+          how many elements are processed and how work stealing can rebalance uneven workloads.
+        </p>
+        <pre><code class="lang-cs">public struct MyParallelJob : IJobParallelFor
+{
+    public NativeArray<float> values;
+    public float deltaTime;
+
+    public void Execute(int index)
+    {
+        values[index] += deltaTime;
+    }
+}</code></pre>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,22 +1,47 @@
+import os
 from pathlib import Path
+
+import pytest
 
 from unity_docs_mcp.bake.extract_manual import extract_manual
 from unity_docs_mcp.bake.extract_scriptref import extract_scriptref
 from unity_docs_mcp.bake.html_to_md import HtmlToTextOptions
 
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+REAL_DOCS_ROOT = Path("data/unity/6000.3/raw/UnityDocumentation/Documentation/en")
+ENABLE_E2E = os.environ.get("UNITYDOCS_E2E") == "1"
+
 
 def test_manual_extraction_smoke():
-    sample = Path("data/unity/6000.3/raw/UnityDocumentation/Documentation/en/Manual/index.html")
-    assert sample.exists(), "Manual index missing; ensure Unity docs present"
+    sample = FIXTURES_DIR / "manual_index.html"
+    assert sample.exists(), "Fixture missing"
     res = extract_manual(sample, HtmlToTextOptions(), drop_sections_list=[])
+    assert "Create and run a job" in res["title"]
     assert len(res["text_md"]) > 200
 
 
 def test_scriptref_extraction_smoke():
-    sample = Path(
-        "data/unity/6000.3/raw/UnityDocumentation/Documentation/en/ScriptReference/Unity.Jobs.IJobParallelFor.html"
-    )
-    assert sample.exists(), "ScriptReference sample missing; ensure Unity docs present"
+    sample = FIXTURES_DIR / "scriptref_iJobParallelFor.html"
+    assert sample.exists(), "Fixture missing"
+    res = extract_scriptref(sample, HtmlToTextOptions())
+    assert "IJobParallelFor" in res["title"]
+    assert len(res["text_md"]) > 200
+
+
+@pytest.mark.skipif(not ENABLE_E2E, reason="set UNITYDOCS_E2E=1 to run real-doc integration tests")
+def test_manual_extraction_real_docs():
+    sample = REAL_DOCS_ROOT / "Manual/index.html"
+    if not sample.exists():
+        pytest.skip("Manual docs not present under data/unity/6000.3/raw")
+    res = extract_manual(sample, HtmlToTextOptions(), drop_sections_list=[])
+    assert len(res["text_md"]) > 200
+
+
+@pytest.mark.skipif(not ENABLE_E2E, reason="set UNITYDOCS_E2E=1 to run real-doc integration tests")
+def test_scriptref_extraction_real_docs():
+    sample = REAL_DOCS_ROOT / "ScriptReference/Unity.Jobs.IJobParallelFor.html"
+    if not sample.exists():
+        pytest.skip("ScriptReference docs not present under data/unity/6000.3/raw")
     res = extract_scriptref(sample, HtmlToTextOptions())
     assert "IJobParallelFor" in res["title"]
     assert len(res["text_md"]) > 200


### PR DESCRIPTION
## Summary
- switch default extraction smoke tests to committed HTML fixtures in 	ests/fixtures
- keep real-doc extraction tests available but gated behind UNITYDOCS_E2E=1
- document optional real-doc extraction test command in docs/README.md

## Why
CI should not require local Unity raw docs under data/, which are intentionally untracked.

## Validation
- pytest -> 2 passed, 2 skipped
- UNITYDOCS_E2E=1 pytest tests/test_extraction.py -> 2 passed, 2 skipped (skips integration when raw docs are absent)

Closes #6
