### PR TITLE
docs: simplify onboarding with no-env default flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,10 @@ bash setup.sh
 - Codex: `examples/codex_mcp_config.json`
 - Claude Desktop: `examples/claude_desktop_config.json`
 - macOS/Linux: `*_unix.json` variants
-
-Set:
-- `UNITY_DOCS_MCP_ROOT` to your local clone path
-- `UNITY_DOCS_MCP_HOST=127.0.0.1`
-- `UNITY_DOCS_MCP_PORT=8765`
+- Replace the `command` value with the absolute path to your local `start_server` script.
+  - Windows example: `C:\\projects\\UnityRAG\\start_server.bat`
+  - macOS/Linux example: `/home/you/UnityRAG/start_server.sh`
+- No env vars are required for the default onboarding flow.
 
 3. Restart your agent and run a prompt:
 - "How do I schedule an `IJobParallelFor` with batch size?"
@@ -76,6 +75,11 @@ unitydocs mcp
 Notes:
 - In `CUDA` mode, setup scripts enforce CUDA torch and fail if no working CUDA runtime is detected.
 - In `CPU-only` mode, setup configures `index.vector: none` and skips vector dependencies.
+
+Optional advanced overrides:
+- `UNITY_DOCS_MCP_ROOT`
+- `UNITY_DOCS_MCP_HOST`
+- `UNITY_DOCS_MCP_PORT`
 
 ## Commands
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,20 +86,15 @@ These require local Unity raw docs under `data/unity/<version>/raw/UnityDocument
 - Link extraction ignores external and anchor-only links; internal links are normalized to doc_ids for related lookups.
 
 ## Codex/Claude MCP wiring (HTTP server, auto-started)
-- Add a server entry pointing to the HTTP launcher inside the venv. Example (Windows):
+- Use `start_server` as the command and set it to an absolute path. Example (Windows):
   ```json
   {
     "servers": {
       "unity-docs": {
-        "command": ".\\.venv\\Scripts\\unitydocs-mcp-http.exe",
-        "args": [],
-        "env": {
-          "UNITY_DOCS_MCP_ROOT": "C:\\projects\\UnityRAG",
-          "UNITY_DOCS_MCP_HOST": "127.0.0.1",
-          "UNITY_DOCS_MCP_PORT": "8765"
-        }
+        "command": "C:\\projects\\UnityRAG\\start_server.bat",
+        "args": []
       }
     }
   }
   ```
-  Alternatively, you can point to `start_server.bat` or `start_server.sh` if you want a visible console window. Adjust the `UNITY_DOCS_MCP_ROOT` path to your clone; with this env the server finds `config.yaml` and data without changing the working directory. Codex/Claude will auto-start the MCP server and connect over HTTP at `http://127.0.0.1:8765/mcp`.
+  macOS/Linux equivalent command: `/path/to/UnityRAG/start_server.sh`. This default flow does not require manually setting `UNITY_DOCS_MCP_ROOT`, `UNITY_DOCS_MCP_HOST`, or `UNITY_DOCS_MCP_PORT`. Use those env vars only if you need custom overrides.

--- a/examples/claude_desktop_config.json
+++ b/examples/claude_desktop_config.json
@@ -1,13 +1,8 @@
 {
   "mcpServers": {
     "unity-docs": {
-      "command": "start_server.bat",
-      "args": [],
-      "env": {
-        "UNITY_DOCS_MCP_ROOT": "C:\\projects\\UnityRAG",
-        "UNITY_DOCS_MCP_HOST": "127.0.0.1",
-        "UNITY_DOCS_MCP_PORT": "8765"
-      }
+      "command": "C:\\path\\to\\UnityRAG\\start_server.bat",
+      "args": []
     }
   }
 }

--- a/examples/claude_desktop_config_unix.json
+++ b/examples/claude_desktop_config_unix.json
@@ -1,13 +1,8 @@
-﻿{
+{
   "mcpServers": {
     "unity-docs": {
-      "command": "./start_server.sh",
-      "args": [],
-      "env": {
-        "UNITY_DOCS_MCP_ROOT": "/path/to/UnityRAG",
-        "UNITY_DOCS_MCP_HOST": "127.0.0.1",
-        "UNITY_DOCS_MCP_PORT": "8765"
-      }
+      "command": "/path/to/UnityRAG/start_server.sh",
+      "args": []
     }
   }
 }

--- a/examples/codex_mcp_config.json
+++ b/examples/codex_mcp_config.json
@@ -1,13 +1,8 @@
 {
   "servers": {
     "unity-docs": {
-      "command": "start_server.bat",
-      "args": [],
-      "env": {
-        "UNITY_DOCS_MCP_ROOT": "C:\\projects\\UnityRAG",
-        "UNITY_DOCS_MCP_HOST": "127.0.0.1",
-        "UNITY_DOCS_MCP_PORT": "8765"
-      }
+      "command": "C:\\path\\to\\UnityRAG\\start_server.bat",
+      "args": []
     }
   }
 }

--- a/examples/codex_mcp_config_unix.json
+++ b/examples/codex_mcp_config_unix.json
@@ -1,13 +1,8 @@
-﻿{
+{
   "servers": {
     "unity-docs": {
-      "command": "./start_server.sh",
-      "args": [],
-      "env": {
-        "UNITY_DOCS_MCP_ROOT": "/path/to/UnityRAG",
-        "UNITY_DOCS_MCP_HOST": "127.0.0.1",
-        "UNITY_DOCS_MCP_PORT": "8765"
-      }
+      "command": "/path/to/UnityRAG/start_server.sh",
+      "args": []
     }
   }
 }


### PR DESCRIPTION
## Summary
- make no-env onboarding the default flow
- update example Codex/Claude configs to use absolute `start_server` command paths
- align README and advanced docs with agent auto-start via config (manual env vars moved to optional overrides)

## Why
Issue #11 describes onboarding friction from unnecessary env-var setup and mixed startup patterns.
closes #11 

## Changes
- removed default `env` blocks from all four example config files
- switched examples to absolute-path placeholders for `start_server.bat` / `start_server.sh`
- updated top-level quickstart to explicitly say no env vars are needed for default onboarding
- updated `docs/README.md` MCP wiring section to the same default pattern

## Validation
- JSON parse check for all `examples/*.json`
