### PR TITLE
Align no-env MCP onboarding across docs and config generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - Data: `data/unity/6000.3/raw` (Unity docs zip + unzip), `data/unity/6000.3/baked`, `data/unity/6000.3/index` (artifact outputs; git-ignored).
 - Scripts/entrypoints: console scripts (`unitydocs-setup`, `unitydocs-bake`, `unitydocs-index`, `unitydocs-mcp`) and wrappers in `scripts/`.
 - Tests: `tests/` (pytest).
-- Config: `config.yaml` optional overrides; defaults baked into code. Paths resolve via `UNITY_DOCS_MCP_ROOT` if set.
+- Config: tracked `config.yaml` base defaults + optional untracked `config.local.yaml` overrides. Paths resolve relative to repo by default, with `UNITY_DOCS_MCP_ROOT` as an advanced override.
 
 ## Build, Test, Run
 - Create env:
@@ -14,14 +14,14 @@
 - Ensure artifacts: `unitydocs-setup` (downloads if missing, bakes, indexes).
 - Bake only: `unitydocs-bake`.
 - Index only: `unitydocs-index` (use `--dry-run` to verify device/model without embedding).
-- MCP server: `unitydocs-mcp` (stdio; Codex config should set `UNITY_DOCS_MCP_ROOT=C:\projects\UnityRAG`).
+- MCP server: `unitydocs-mcp` (stdio; setup can auto-configure Codex/Claude with absolute command paths, no env vars required for default flow).
 - Tests: `pytest`.
 
 ## Coding Style & Naming
 - Python 3.12+, 4-space indentation, type hints throughout.
 - Keep functions small; prefer explicit names (`bake_*`, `index_*`, `ensure_*`).
 - Inline comments only for non-obvious logic (e.g., path resolution, CUDA selection).
-- Avoid machine-specific absolute paths in committed files; rely on env for roots.
+- Avoid machine-specific absolute paths in committed files; rely on repo-relative defaults unless advanced env overrides are needed.
 
 ## Testing Guidelines
 - Framework: pytest.
@@ -35,5 +35,5 @@
 
 ## Security & Config Tips
 - Keep secrets out of repo; no tokens in config.
-- Use `UNITY_DOCS_MCP_ROOT`/`UNITY_DOCS_MCP_CONFIG` to locate data/config without changing working dir.
+- Use `UNITY_DOCS_MCP_ROOT`/`UNITY_DOCS_MCP_CONFIG` only when you need advanced root/config overrides.
 - For GPU: install CUDA-enabled torch in the venv (setup probes `cu128`, then `cu121`, then `cu118`) and verifies `torch.cuda.is_available()` at runtime.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Setup will prompt you for:
 - "How do I schedule an `IJobParallelFor` with batch size?"
 - "Open `Mesh.SetVertices` and show related docs."
 
-If you chose `Skip`, configure manually using files in `examples/` with an absolute `unitydocs-mcp` path plus `UNITY_DOCS_MCP_ROOT` and `UNITY_DOCS_MCP_CONFIG`.
+If you chose `Skip`, configure manually using files in `examples/` with an absolute `unitydocs-mcp` path.
 
 If setup fails, run:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -89,19 +89,16 @@ These require local Unity raw docs under `data/unity/<version>/raw/UnityDocument
 
 ## Codex/Claude MCP wiring (stdio MCP, auto-started)
 - Setup can auto-configure Codex/Claude MCP files now (recommended).
-- If you need manual wiring, use the repo venv `unitydocs-mcp` entrypoint with absolute paths plus env overrides. Example (Windows):
+- If you need manual wiring, use the repo venv `unitydocs-mcp` entrypoint with an absolute path. Example (Windows):
   ```json
   {
     "servers": {
       "unity-docs": {
         "command": "C:\\projects\\UnityRAG\\.venv\\Scripts\\unitydocs-mcp.exe",
-        "args": [],
-        "env": {
-          "UNITY_DOCS_MCP_ROOT": "C:\\projects\\UnityRAG",
-          "UNITY_DOCS_MCP_CONFIG": "C:\\projects\\UnityRAG\\config.local.yaml"
-        }
+        "args": []
       }
     }
   }
   ```
   macOS/Linux equivalent command: `/path/to/UnityRAG/.venv/bin/unitydocs-mcp`.
+- Optional advanced overrides remain available via `UNITY_DOCS_MCP_ROOT` / `UNITY_DOCS_MCP_CONFIG`.

--- a/docs/internal/codex_notes.md
+++ b/docs/internal/codex_notes.md
@@ -52,7 +52,7 @@
 [2026-01-10 04:20] setup.bat now creates .venv if missing, installs deps, checks free disk space, and supports optional repo-local portable Python 3.12 download (only if no 3.12 found).
 [2026-01-10 04:25] Added banner.txt and setup.bat displays banner; added colored output helpers and success/failure pauses for user-visible setup flow.
 [2026-01-10 04:30] Fixed setup.bat path normalization and removed where-python probing to avoid Windows path/volume label errors.
-[2026-02-20 15:25] Carry-forward rules: setup scripts are CUDA-only and must never silently fall back to CPU torch.
+[2026-02-20 15:25] SUPERSEDED by 2026-02-20 16:10 CPU-only mode support. Historical rule: setup scripts are CUDA-only and must never silently fall back to CPU torch.
 [2026-02-20 15:25] CUDA channel fallback must be runtime-verified (torch.cuda.is_available + torch.version.cuda), not install-success only.
 [2026-02-20 15:25] MCP stdio stability: keep setup/embed diagnostics off stdout (stderr only) to avoid transport/protocol breakage.
 [2026-02-20 15:25] Ensure flow: avoid forcing raw zip/unzip when baked/index artifacts are already valid for current config signature.
@@ -62,7 +62,8 @@
 [2026-02-20 15:45] Started issue #2 implementation plan: add unitydocs doctor with human/json output, preflight diagnostics, and non-zero exit on blocking failures.
 [2026-02-20 16:10] Decision update: support CPU-only environments via explicit FTS-only mode (index.vector=none) while keeping CUDA hybrid as default for full semantic retrieval.
 [2026-02-20 16:10] setup.bat/setup.sh now prompt for CUDA vs CPU-only and install dependency sets accordingly (. [dev,vector] vs . [dev]); FTS-only path skips torch/sentence-transformers/faiss runtime logic.
-[2026-02-20 16:15] Setup mode/version selection now persists into repo config.yaml (not temp-only) so MCP startup uses the same retrieval mode after setup.
+[2026-02-20 16:15] SUPERSEDED by 2026-02-20 18:20 layered config model. Historical note: setup mode/version selection persisted into repo config.yaml.
 [2026-02-20 15:35] Reduced onboarding friction: setup now prompts for Codex/Claude MCP auto-config and writes client config entries automatically via unity_docs_mcp.setup.mcp_config.
-[2026-02-20 17:50] MCP auto-config now writes absolute repo venv stdio command (`unitydocs-mcp`) plus UNITY_DOCS_MCP_ROOT/UNITY_DOCS_MCP_CONFIG env to avoid CWD-dependent startup failures across projects.
+[2026-02-20 17:50] SUPERSEDED by 2026-02-20 19:00 no-env default MCP config. Historical note: MCP auto-config wrote absolute `unitydocs-mcp` command plus UNITY_DOCS_MCP_ROOT/UNITY_DOCS_MCP_CONFIG env.
 [2026-02-20 18:20] Config model switched to layered load: tracked `config.yaml` base + untracked `config.local.yaml` setup overrides, with env/explicit paths as higher-precedence overlays.
+[2026-02-20 19:00] No-env onboarding default aligned across README/docs/examples/setup generator: Codex/Claude MCP configs now default to absolute `unitydocs-mcp` command with no env block; env vars remain advanced-only overrides.

--- a/examples/claude_desktop_config.json
+++ b/examples/claude_desktop_config.json
@@ -2,11 +2,7 @@
   "mcpServers": {
     "unity-docs": {
       "command": "C:\\path\\to\\UnityRAG\\.venv\\Scripts\\unitydocs-mcp.exe",
-      "args": [],
-      "env": {
-        "UNITY_DOCS_MCP_ROOT": "C:\\path\\to\\UnityRAG",
-        "UNITY_DOCS_MCP_CONFIG": "C:\\path\\to\\UnityRAG\\config.local.yaml"
-      }
+      "args": []
     }
   }
 }

--- a/examples/claude_desktop_config_unix.json
+++ b/examples/claude_desktop_config_unix.json
@@ -2,11 +2,7 @@
   "mcpServers": {
     "unity-docs": {
       "command": "/path/to/UnityRAG/.venv/bin/unitydocs-mcp",
-      "args": [],
-      "env": {
-        "UNITY_DOCS_MCP_ROOT": "/path/to/UnityRAG",
-        "UNITY_DOCS_MCP_CONFIG": "/path/to/UnityRAG/config.local.yaml"
-      }
+      "args": []
     }
   }
 }

--- a/examples/codex_mcp_config.json
+++ b/examples/codex_mcp_config.json
@@ -2,11 +2,7 @@
   "servers": {
     "unity-docs": {
       "command": "C:\\path\\to\\UnityRAG\\.venv\\Scripts\\unitydocs-mcp.exe",
-      "args": [],
-      "env": {
-        "UNITY_DOCS_MCP_ROOT": "C:\\path\\to\\UnityRAG",
-        "UNITY_DOCS_MCP_CONFIG": "C:\\path\\to\\UnityRAG\\config.local.yaml"
-      }
+      "args": []
     }
   }
 }

--- a/examples/codex_mcp_config_unix.json
+++ b/examples/codex_mcp_config_unix.json
@@ -2,11 +2,7 @@
   "servers": {
     "unity-docs": {
       "command": "/path/to/UnityRAG/.venv/bin/unitydocs-mcp",
-      "args": [],
-      "env": {
-        "UNITY_DOCS_MCP_ROOT": "/path/to/UnityRAG",
-        "UNITY_DOCS_MCP_CONFIG": "/path/to/UnityRAG/config.local.yaml"
-      }
+      "args": []
     }
   }
 }

--- a/src/unity_docs_mcp/setup/mcp_config.py
+++ b/src/unity_docs_mcp/setup/mcp_config.py
@@ -22,10 +22,6 @@ def _server_config(repo_root: Path) -> dict[str, Any]:
     return {
         "command": str(command),
         "args": [],
-        "env": {
-            "UNITY_DOCS_MCP_ROOT": str(root),
-            "UNITY_DOCS_MCP_CONFIG": str(root / "config.local.yaml"),
-        },
     }
 
 

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -35,10 +35,7 @@ def test_install_mcp_config_creates_new_file(tmp_path: Path):
     assert "unity-docs" in data["servers"]
     assert data["servers"]["unity-docs"]["command"] == str(launcher.resolve())
     assert data["servers"]["unity-docs"]["args"] == []
-    assert data["servers"]["unity-docs"]["env"]["UNITY_DOCS_MCP_ROOT"] == str(repo_root.resolve())
-    assert data["servers"]["unity-docs"]["env"]["UNITY_DOCS_MCP_CONFIG"] == str(
-        (repo_root / "config.local.yaml").resolve()
-    )
+    assert "env" not in data["servers"]["unity-docs"]
 
 
 def test_install_mcp_config_preserves_other_servers_and_creates_backup(tmp_path: Path):


### PR DESCRIPTION
## Summary
- remove default MCP env injection from install_mcp_config so generated entries are command-only by default
- update all examples/*.json to the no-env default pattern
- align README.md and docs/README.md manual wiring guidance with absolute command path only
- sync AGENTS.md to layered config + advanced-only env override guidance
- mark superseded decisions in docs/internal/codex_notes.md and log the no-env default decision

## Why
Issue #11 calls out onboarding friction from env-var-heavy defaults. This PR makes the default MCP onboarding path no-env across code and docs while preserving env vars as advanced overrides.

## Validation
- .venv\\Scripts\\python -m pytest tests/test_mcp_config.py
- .venv\\Scripts\\python -m pytest
- JSON parse check for examples/*.json

Closes #11
