### PR TITLE
chore: force setup scripts to CPU-only while CUDA path is WIP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 ## Build, Test, Run
 - Create env:
   - CPU/FTS-only: `python -m venv .venv && .venv\Scripts\activate && pip install -e .[dev]`
-  - CUDA/hybrid: `python -m venv .venv && .venv\Scripts\activate && pip install -e .[dev,vector]`
+  - CUDA/hybrid (WIP): `python -m venv .venv && .venv\Scripts\activate && pip install -e .[dev,vector]` (manual/experimental; setup scripts currently force CPU-only)
 - Ensure artifacts: `unitydocs-setup` (downloads if missing, bakes, indexes).
 - Bake only: `unitydocs-bake`.
 - Index only: `unitydocs-index` (use `--dry-run` to verify device/model without embedding).
@@ -38,4 +38,4 @@
 ## Security & Config Tips
 - Keep secrets out of repo; no tokens in config.
 - Use `UNITY_DOCS_MCP_ROOT`/`UNITY_DOCS_MCP_CONFIG` only when you need advanced root/config overrides.
-- For GPU: install CUDA-enabled torch in the venv (setup probes `cu128`, then `cu121`, then `cu118`) and verifies `torch.cuda.is_available()` at runtime.
+- CUDA/hybrid setup is temporarily WIP. `setup.bat`/`setup.sh` currently force CPU-only; use manual GPU setup only for experimental testing.

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ bash setup.sh
 ```
 
 Setup will prompt you for:
-- Retrieval mode: `CUDA` (hybrid) or `CPU-only` (FTS-only)
 - Unity docs version (auto-suggested from detected local Unity editor installs; you can override)
 - MCP client auto-config: `Codex`, `Claude Desktop`, `Both`, or `Skip`
 - Setup writes machine-local mode overrides to `config.local.yaml` (untracked), while `config.yaml` remains tracked defaults.
 - MCP server configs include `UNITY_DOCS_MCP_UNITY_VERSION` so clients run against your selected docs version.
+- Setup currently forces `CPU-only` (`index.vector: none`) while CUDA/hybrid setup is WIP.
 
 2. Restart your agent.
 
@@ -115,7 +115,8 @@ python -m venv .venv
 # Windows: .\.venv\Scripts\activate
 # macOS/Linux: source .venv/bin/activate
 pip install -e .[dev]
-# For CUDA/hybrid installs, use:
+# CUDA/hybrid path is currently WIP in setup scripts.
+# Manual experimental install:
 # pip install -e .[dev,vector]
 export UNITY_DOCS_MCP_UNITY_VERSION=6000.3  # Windows PowerShell: $env:UNITY_DOCS_MCP_UNITY_VERSION='6000.3'
 unitydocs install --version 6000.3 --cleanup
@@ -123,8 +124,8 @@ unitydocs mcp
 ```
 
 Notes:
-- In `CUDA` mode, setup scripts enforce CUDA torch and fail if no working CUDA runtime is detected.
-- In `CPU-only` mode, setup configures `index.vector: none` and skips vector dependencies.
+- Setup scripts currently force `CPU-only` mode and configure `index.vector: none`.
+- CUDA/hybrid setup is temporarily WIP; use manual vector installs only if you are testing that path.
 
 Optional advanced overrides:
 - `UNITY_DOCS_MCP_UNITY_VERSION` (required for runtime commands such as `unitydocs mcp`)

--- a/setup.bat
+++ b/setup.bat
@@ -77,34 +77,13 @@ if defined FREE_GB if %FREE_GB% LSS %REQUIRED_GB% (
   exit /b 1
 )
 
-set "SETUP_MODE="
-if /i "%UNITYDOCS_SETUP_MODE%"=="cuda" set "SETUP_MODE=cuda"
-if /i "%UNITYDOCS_SETUP_MODE%"=="1" set "SETUP_MODE=cuda"
-if /i "%UNITYDOCS_SETUP_MODE%"=="cpu" set "SETUP_MODE=cpu"
-if /i "%UNITYDOCS_SETUP_MODE%"=="2" set "SETUP_MODE=cpu"
-
-if not defined SETUP_MODE goto choose_mode
-goto after_choose_mode
-
-:choose_mode
-echo.
-call :print_color Green "[detect] Select setup mode:"
-echo   1^) CUDA ^(hybrid retrieval: FTS + vectors^)
-echo   2^) CPU-only ^(FTS-only retrieval; no transformers/faiss^)
-echo.
-set "SETUP_MODE="
-set /p MODE_CHOICE=Mode [1]:
-if "%MODE_CHOICE%"=="" set "MODE_CHOICE=1"
-if /i "%MODE_CHOICE%"=="1" set "SETUP_MODE=cuda"
-if /i "%MODE_CHOICE%"=="cuda" set "SETUP_MODE=cuda"
-if /i "%MODE_CHOICE%"=="2" set "SETUP_MODE=cpu"
-if /i "%MODE_CHOICE%"=="cpu" set "SETUP_MODE=cpu"
-if not defined SETUP_MODE (
-  call :print_color Red "Invalid mode selection."
-  goto choose_mode
+set "SETUP_MODE=cpu"
+if defined UNITYDOCS_SETUP_MODE (
+  if /i "%UNITYDOCS_SETUP_MODE%"=="cuda" call :print_color Yellow "[setup] CUDA setup is temporarily disabled (WIP). Forcing CPU-only mode."
+  if /i "%UNITYDOCS_SETUP_MODE%"=="1" call :print_color Yellow "[setup] CUDA setup is temporarily disabled (WIP). Forcing CPU-only mode."
+) else (
+  call :print_color Yellow "[setup] CUDA setup is temporarily disabled (WIP). Using CPU-only mode."
 )
-
-:after_choose_mode
 
 call :print_color Cyan "[bootstrap] Preparing virtual environment and dependencies..."
 set "PYTHONPATH=%REPO%\src"

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV_DIR="$REPO_DIR/.venv"
-SETUP_MODE="${UNITYDOCS_SETUP_MODE:-}"
+REQUESTED_SETUP_MODE="${UNITYDOCS_SETUP_MODE:-}"
+SETUP_MODE="cpu"
 SETUP_DIAG_LATEST="$REPO_DIR/reports/setup/setup-diagnostics-latest.json"
 VERSION_FROM_ARG=0
 VERSION="6000.3"
@@ -39,32 +40,20 @@ if [ -n "${1:-}" ]; then
   VERSION_FROM_ARG=1
 fi
 
-if [ -z "$SETUP_MODE" ]; then
-  echo
-  echo "[detect] Select setup mode:"
-  echo "  1) CUDA (hybrid retrieval: FTS + vectors)"
-  echo "  2) CPU-only (FTS-only retrieval; no transformers/faiss)"
-  read -r -p "Mode [1]: " MODE_CHOICE
-  MODE_CHOICE="${MODE_CHOICE:-1}"
-  MODE_CHOICE_LOWER="$(printf '%s' "$MODE_CHOICE" | tr '[:upper:]' '[:lower:]')"
-  case "$MODE_CHOICE_LOWER" in
-    1|cuda) SETUP_MODE="cuda" ;;
-    2|cpu) SETUP_MODE="cpu" ;;
+if [ -n "$REQUESTED_SETUP_MODE" ]; then
+  REQUESTED_SETUP_MODE_LOWER="$(printf '%s' "$REQUESTED_SETUP_MODE" | tr '[:upper:]' '[:lower:]')"
+  case "$REQUESTED_SETUP_MODE_LOWER" in
+    1|cuda)
+      echo "[setup] CUDA setup is temporarily disabled (WIP). Forcing CPU-only mode."
+      ;;
+    2|cpu)
+      ;;
     *)
-      echo "[setup] Invalid mode selection."
-      exit 1
+      echo "[setup] UNITYDOCS_SETUP_MODE currently supports CPU-only setup while CUDA is WIP. Forcing CPU-only mode."
       ;;
   esac
 else
-  SETUP_MODE_LOWER="$(printf '%s' "$SETUP_MODE" | tr '[:upper:]' '[:lower:]')"
-  case "$SETUP_MODE_LOWER" in
-    1|cuda) SETUP_MODE="cuda" ;;
-    2|cpu) SETUP_MODE="cpu" ;;
-    *)
-      echo "[setup] UNITYDOCS_SETUP_MODE must be cuda or cpu."
-      exit 1
-      ;;
-  esac
+  echo "[setup] CUDA setup is temporarily disabled (WIP). Using CPU-only mode."
 fi
 
 if command -v python3.12 >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- remove interactive CUDA/CPU mode choice from setup.bat and setup.sh
- force setup mode to CPU-only and keep index.vector: none behavior
- add clear WIP messaging when CUDA is requested via env
- update README.md and AGENTS.md to document that CUDA/hybrid setup is temporarily WIP

## Testing
- not run (script/docs changes only)